### PR TITLE
Fix building recastx-gui on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .DS_Store
+CMakePresets.json
 
 .idea
 .vscode
+.vs
 
 version.hpp
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ option(BENCHMARK "Build with benchmarking configurations" OFF)
 # VERBOSITY values:
 # - 0: no verbosity
 # - 1: general performance benchmarks
-# - 2: performance benchmark of critical functions, 
+# - 2: performance benchmark of critical functions,
 #      monitoring occupation of the memory buffer
 # - 3: communications between the GUI and the reconstruction server
 # - 4: received image data information (type, frame id, etc.),
@@ -46,9 +46,11 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
 endif()
 
-set(CMAKE_CXX_FLAGS "-Wno-unused-result")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
-set(CMAKE_CXX_FLAGS_DEBUG "-g")
+if(NOT WIN32)
+    set(CMAKE_CXX_FLAGS "-Wno-unused-result")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
+    set(CMAKE_CXX_FLAGS_DEBUG "-g")
+endif()
 
 set(CMAKE_INSTALL_PREFIX ${CMAKE_PREFIX_PATH})
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
@@ -80,7 +82,7 @@ if (BUILD_TEST)
         GIT_REPOSITORY https://github.com/google/googletest.git
         GIT_TAG v1.13.0
     )
-    
+
     # For Windows: Prevent overriding the parent project's compiler/linker settings
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(googletest)

--- a/common/include/common/utils.hpp
+++ b/common/include/common/utils.hpp
@@ -17,7 +17,7 @@
 namespace recastx {
 
 inline size_t sliceIdFromTimestamp(size_t ts) {
-    return ts % MAX_NUM_SLICES; 
+    return ts % MAX_NUM_SLICES;
 }
 
 inline size_t expandDataSize(size_t s, size_t chunk_size) {
@@ -27,8 +27,8 @@ inline size_t expandDataSize(size_t s, size_t chunk_size) {
 template<typename T>
 inline void arrayStat(const T& arr, std::array<size_t, 2> shape, const std::string& message = "") {
     double avg = 0;
-    double min = std::numeric_limits<double>::max();
-    double max = std::numeric_limits<double>::min();
+    double min = (std::numeric_limits<double>::max)();
+    double max = (std::numeric_limits<double>::min)();
     for (size_t j = 0; j < shape[0]; ++j) {
         for (size_t k = 0; k < shape[1]; ++k) {
             auto v = arr[j * shape[1] + k];
@@ -47,8 +47,8 @@ inline void arrayStat(const T& arr, std::array<size_t, 2> shape, const std::stri
 }
 
 template<typename T>
-void computeHistogram(const std::vector<T>& data, double left, double right, size_t num_bins,
-                      std::pair<std::vector<T>, std::vector<T>>& output) {
+inline void computeHistogram(const std::vector<T>& data, double left, double right, size_t num_bins,
+                             std::pair<std::vector<T>, std::vector<T>>& output) {
     auto& bin_centers = output.first;
     auto& bin_counts = output.second;
 
@@ -60,7 +60,7 @@ void computeHistogram(const std::vector<T>& data, double left, double right, siz
         right += 0.5;
     }
 
-    double norm = 1 / (right - left);
+    double norm = 1. / (right - left);
     size_t counted = 0;
     for (size_t i = 0; i < data.size(); ++i) {
         auto v = static_cast<double>(data[i]);
@@ -75,14 +75,14 @@ void computeHistogram(const std::vector<T>& data, double left, double right, siz
     }
 
     double bin_width = (right - left) / num_bins;
-    bin_centers[0] = left + 0.5 * bin_width;
+    bin_centers[0] = static_cast<T>(left + 0.5 * bin_width);
     for (size_t i = 1; i < bin_centers.size(); ++i) {
-        bin_centers[i] += bin_centers[i - 1] + bin_width;
+        bin_centers[i] += static_cast<T>(bin_centers[i - 1] + bin_width);
     }
 
-    double scale = 1.f / (counted * bin_width);
+    double scale = 1. / (counted * bin_width);
     for (size_t i = 0; i < num_bins; ++i) {
-        bin_counts[i] *= scale;
+        bin_counts[i] *= static_cast<T>(scale);
     }
 }
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -36,15 +36,17 @@ TBD
 
 #### Installing the GUI client
 
-- Linux / MacOS
-
-```bash
+```sh
 git clone --recursive https://github.com/<repo>/recastx.git
 cd recastx
 
 conda env create -f environment-gui.yml
 conda activate recastx-gui
+```
 
+- Linux / MacOS
+
+```sh
 mkdir build-gui && cd build-gui
 cmake .. -DCMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"} \
          -DBUILD_GUI=ON
@@ -53,7 +55,12 @@ make -j12 && make install
 
 - Windows
 
-TBD
+```sh
+
+cmake -G "Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH=C:\Users\Jun\miniconda3\envs\recastx-gui -DBUILD_GUI=ON ..
+
+cmake --build . --config Release --parallel 12
+```
 
 ## Package managers
 

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -104,26 +104,32 @@ target_include_directories(${TARGET_NAME}
                 ${IMPLOT_DIR}
                 ${GL3W_BUILD_DIR}/include
 )
-target_link_libraries(${TARGET_NAME}
-        PRIVATE dl
-                glfw
-                OpenGL::GL
-                glm::glm
-                ${FREETYPE_LIBRARIES}
-                pthread
-                Eigen3::Eigen
-                Boost::program_options
-                spdlog::spdlog
-                recastx_grpc_proto
-                recastx_models
-        )
 
-if (UNIX AND NOT APPLE)
-    # required by glfw
-    target_link_libraries(${TARGET_NAME} PRIVATE X11)
+target_link_libraries(${TARGET_NAME} PRIVATE
+        glfw
+        OpenGL::GL
+        glm::glm
+        ${FREETYPE_LIBRARIES}
+        Eigen3::Eigen
+        Boost::program_options
+        spdlog::spdlog
+        recastx_grpc_proto
+        recastx_models
+)
+
+if (NOT WIN32)
+        target_link_libraries(${TARGET_NAME} PRIVATE dl)
+        target_compile_options(${TARGET_NAME} PRIVATE -Wall -Wextra -Wfatal-errors)
+else()
+        target_compile_options(${TARGET_NAME} PRIVATE /W4 /WX)
 endif()
 
-target_compile_options(${TARGET_NAME} PRIVATE -Wall -Wextra -Wfatal-errors)
+if (UNIX AND NOT APPLE)
+        # required by glfw
+        target_link_libraries(${TARGET_NAME} PRIVATE X11)
+endif()
+
+
 # This is to work around GLM issue#754 <https://github.com/g-truc/glm/issues/754>
 target_compile_definitions(${TARGET_NAME}
         PUBLIC -DVERBOSITY=${VERBOSITY}

--- a/gui/include/graphics/component.hpp
+++ b/gui/include/graphics/component.hpp
@@ -33,7 +33,7 @@ class Component {
 
     virtual void draw(rpc::ServerState_State state) = 0;
 
-    virtual RpcClient::State updateServerParams() const { return RpcClient::State::OK; };
+    virtual RpcClient::State updateServerParams() const { return RpcClient::State::SUCCESS; };
 
     virtual void preRender() {}
 };

--- a/gui/include/graphics/marcher.hpp
+++ b/gui/include/graphics/marcher.hpp
@@ -355,7 +355,8 @@ class Marcher {
         if (z >= data.z()) z = data.z() - 1;
         int index = (z * data.y() + y) * data.x() + x;
 
-        return data.data()[index];
+        // TODO: check
+        return static_cast<uint8_t>(data.data()[index]);
     }
 
     glm::vec3 normalAt(const DataType& data, int x, int y, int z) {

--- a/gui/include/graphics/material.hpp
+++ b/gui/include/graphics/material.hpp
@@ -9,6 +9,7 @@
 #ifndef GUI_MATERIAL_H
 #define GUI_MATERIAL_H
 
+#include <array>
 #include <optional>
 
 #include <glm/glm.hpp>

--- a/gui/include/graphics/material_manager.hpp
+++ b/gui/include/graphics/material_manager.hpp
@@ -45,7 +45,6 @@ class MaterialManager {
     T* getMaterial(MaterialID id) {
         if constexpr (std::is_base_of_v<T, MeshMaterial>) return mesh_materials_.at(id).get();
         if constexpr (std::is_base_of_v<T, TransferFunc>) return transfer_funcs_.at(id).get();
-        return nullptr;
     }
 
     Widget* getWidget(MaterialID id) {  return widgets_.at(id).get(); }

--- a/gui/include/graphics/preproc_component.hpp
+++ b/gui/include/graphics/preproc_component.hpp
@@ -6,8 +6,8 @@
  *
  * The full license is in the file LICENSE, distributed with this software.
 */
-#ifndef RECASTX_PREPROC_COMPONENT_HPP
-#define RECASTX_PREPROC_COMPONENT_HPP
+#ifndef RECASTX_PREPROC_COMPONENT_H
+#define RECASTX_PREPROC_COMPONENT_H
 
 #include <map>
 #include <string>
@@ -44,4 +44,4 @@ class PreprocComponent : public Component {
 
 } // namespace recastx::gui
 
-#endif //RECASTX_PREPROC_COMPONENT_HPP
+#endif //RECASTX_PREPROC_COMPONENT_H

--- a/gui/include/graphics/scan_component.hpp
+++ b/gui/include/graphics/scan_component.hpp
@@ -6,8 +6,8 @@
  *
  * The full license is in the file LICENSE, distributed with this software.
 */
-#ifndef RECASTX_SCAN_COMPONENT_HPP
-#define RECASTX_SCAN_COMPONENT_HPP
+#ifndef RECASTX_SCAN_COMPONENT_H
+#define RECASTX_SCAN_COMPONENT_H
 
 #include <map>
 #include <string>
@@ -34,4 +34,4 @@ class ScanComponent : public Component {
 
 } // namespace recastx::gui
 
-#endif //RECASTX_SCAN_COMPONENT_HPP
+#endif //RECASTX_SCAN_COMPONENT_H

--- a/gui/include/graphics/slice_component.hpp
+++ b/gui/include/graphics/slice_component.hpp
@@ -6,8 +6,8 @@
  *
  * The full license is in the file LICENSE, distributed with this software.
 */
-#ifndef GUI_SLICE_H
-#define GUI_SLICE_H
+#ifndef GUI_SLICE_COMPONENT_H
+#define GUI_SLICE_COMPONENT_H
 
 #include <array>
 #include <cstddef>
@@ -86,4 +86,4 @@ public:
 
 } // namespace recastx::gui
 
-#endif // GUI_SLICE_H
+#endif // GUI_SLICE_COMPONENT_H

--- a/gui/include/graphics/volume_component.hpp
+++ b/gui/include/graphics/volume_component.hpp
@@ -6,8 +6,8 @@
  *
  * The full license is in the file LICENSE, distributed with this software.
 */
-#ifndef GUI_VOLUME_H
-#define GUI_VOLUME_H
+#ifndef GUI_VOLUME_COMPONENT_H
+#define GUI_VOLUME_COMPONENT_H
 
 #include <array>
 #include <memory>
@@ -91,4 +91,4 @@ class VolumeComponent : public Component {
 
 } // namespace recastx::gui
 
-#endif // GUI_VOLUME_H
+#endif // GUI_VOLUME_COMPONENT_H

--- a/gui/include/rpc_client.hpp
+++ b/gui/include/rpc_client.hpp
@@ -9,6 +9,7 @@
 #ifndef GUI_RPCCLIENT_H
 #define GUI_RPCCLIENT_H
 
+#include <algorithm>
 #include <atomic>
 #include <cstring>
 #include <map>
@@ -39,8 +40,8 @@ class RpcClient {
   public:
 
     enum class State {
-        OK = 0,
-        ERROR = 1
+        SUCCESS = 0,
+        FAILURE = 1
     };
 
     using DataType = std::variant<rpc::ReconData, rpc::ProjectionData>;
@@ -77,9 +78,9 @@ class RpcClient {
     ThreadSafeQueue<DataType> packets_;
 
     void updateTimeout(int& timeout, const grpc::Status& status) {
-        if (checkStatus(status, false) != State::OK) {
+        if (checkStatus(status, false) != State::SUCCESS) {
             std::this_thread::sleep_for(std::chrono::milliseconds(timeout));
-            timeout = std::min(2 * timeout, max_timeout);
+            timeout = (std::min)(2 * timeout, max_timeout);
         } else {
             timeout = min_timeout;
         }
@@ -139,7 +140,7 @@ class RpcClient {
 };
 
 #define CHECK_CLIENT_STATE(x) { RpcClient::State ret = x;\
-    if (ret != RpcClient::State::OK) return ret; }
+    if (ret != RpcClient::State::SUCCESS) return ret; }
 
 }  // namespace recastx::gui
 

--- a/gui/src/application.cpp
+++ b/gui/src/application.cpp
@@ -174,19 +174,19 @@ void Application::connectServer() {
 }
 
 void Application::startAcquiring() {
-    if (updateServerParams() != RpcClient::State::OK) {
+    if (updateServerParams() != RpcClient::State::SUCCESS) {
         server_state_ = rpc::ServerState_State_UNKNOWN;
         return;
     }
 
-    if (rpc_client_->startAcquiring() == RpcClient::State::OK) {
+    if (rpc_client_->startAcquiring() == RpcClient::State::SUCCESS) {
         server_state_ = rpc::ServerState_State_ACQUIRING;
         log::info("Started acquiring data");
     }
 }
 
 void Application::stopAcquiring() {
-    if (rpc_client_->stopAcquiring() == RpcClient::State::OK) {
+    if (rpc_client_->stopAcquiring() == RpcClient::State::SUCCESS) {
         server_state_ = rpc::ServerState_State_READY;
         log::info("Stopped acquiring data");
     } else {
@@ -195,19 +195,19 @@ void Application::stopAcquiring() {
 }
 
 void Application::startProcessing() {
-    if (updateServerParams() != RpcClient::State::OK) {
+    if (updateServerParams() != RpcClient::State::SUCCESS) {
         server_state_ = rpc::ServerState_State_UNKNOWN;
         return;
     }
 
-    if (rpc_client_->startProcessing() == RpcClient::State::OK) {
+    if (rpc_client_->startProcessing() == RpcClient::State::SUCCESS) {
         server_state_ = rpc::ServerState_State_PROCESSING;
         log::info("Started acquiring & processing data");
     }
 }
 
 void Application::stopProcessing() {
-    if (rpc_client_->stopProcessing() == RpcClient::State::OK) {
+    if (rpc_client_->stopProcessing() == RpcClient::State::SUCCESS) {
         server_state_ = rpc::ServerState_State_READY;
         log::info("Stopped acquiring & processing data");
     } else {
@@ -287,7 +287,7 @@ RpcClient::State Application::updateServerParams() {
     for (auto comp : components_) {
         CHECK_CLIENT_STATE(comp->updateServerParams())
     }
-    return RpcClient::State::OK;
+    return RpcClient::State::SUCCESS;
 }
 
 void Application::startConsumer() {

--- a/gui/src/graphics/aesthetics.cpp
+++ b/gui/src/graphics/aesthetics.cpp
@@ -92,7 +92,7 @@ void Alphamap::set(const std::map<float, float>& alphamap) {
     }
     while (j < n) data_[j++] = alpha.back();
 
-    setData(data_.data(), data_.size(), 1);
+    setData(data_.data(), static_cast<int>(data_.size()), 1);
 }
 
 } // namespace recastx::gui

--- a/gui/src/graphics/geometry_component.cpp
+++ b/gui/src/graphics/geometry_component.cpp
@@ -66,7 +66,7 @@ RpcClient::State GeometryComponent::updateServerParams() const {
                                                       static_cast<int>(angle_range_)))
     CHECK_CLIENT_STATE(client_->setReconGeometry(slice_size_, volume_size_,
                                                  {x_[0], x_[1]}, {y_[0], y_[1]}, {z_[0], z_[1]}))
-    return RpcClient::State::OK;
+    return RpcClient::State::SUCCESS;
 }
 
 } // namespace recastx::gui

--- a/gui/src/graphics/light_object.cpp
+++ b/gui/src/graphics/light_object.cpp
@@ -32,7 +32,7 @@ void LightObject::render(Renderer* renderer) {
     shader_->setVec3("color", light_->color()); // the only difference from SimpleObject::render(Renderer*)
 
     glBindVertexArray(VAO_);
-    glDrawElements(GL_LINES, model_.indices.size(), GL_UNSIGNED_INT, 0);
+    glDrawElements(GL_LINES, static_cast<GLsizei>(model_.indices.size()), GL_UNSIGNED_INT, 0);
 }
 
 void LightObject::setLightModel() {

--- a/gui/src/graphics/mesh.cpp
+++ b/gui/src/graphics/mesh.cpp
@@ -56,9 +56,9 @@ Mesh::Mesh(Mesh &&other) noexcept
 void Mesh::render() const {
     glBindVertexArray(VAO_);
     if (!indices_.empty()) {
-        glDrawElements(GL_TRIANGLES, indices_.size(), GL_UNSIGNED_INT, 0);
+        glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(indices_.size()), GL_UNSIGNED_INT, 0);
     } else {
-        glDrawArrays(GL_TRIANGLES, 0, vertices_.size());
+        glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(vertices_.size()));
     }
     glBindVertexArray(0);
 }

--- a/gui/src/graphics/preproc_component.cpp
+++ b/gui/src/graphics/preproc_component.cpp
@@ -82,7 +82,7 @@ RpcClient::State PreprocComponent::updateServerParams() const {
     CHECK_CLIENT_STATE(client_->setDownsampling(downsampling_col_, downsampling_row_))
     CHECK_CLIENT_STATE(client_->setCorrection(offset_, minus_log_))
     CHECK_CLIENT_STATE(client_->setRampFilter(ramp_filter_name_))
-    return RpcClient::State::OK;
+    return RpcClient::State::SUCCESS;
 }
 
 } // namespace recastx::gui

--- a/gui/src/graphics/projection_component.cpp
+++ b/gui/src/graphics/projection_component.cpp
@@ -55,7 +55,7 @@ void ProjectionComponent::draw(rpc::ServerState_State) {
 
 RpcClient::State ProjectionComponent::updateServerParams() const {
     CHECK_CLIENT_STATE(client_->setProjection(id_))
-    return RpcClient::State::OK;
+    return RpcClient::State::SUCCESS;
 }
 
 void ProjectionComponent::setData(uint32_t id, const std::string& data, uint32_t x, uint32_t y) {

--- a/gui/src/graphics/scene.cpp
+++ b/gui/src/graphics/scene.cpp
@@ -195,7 +195,7 @@ Interactable* Scene::findClosestSlice(float x, float y) const {
     auto point2 = prev_inv_vp_ * glm::vec4(x, y,  1.f, 1.f);
     point2 /= point2[3];
 
-    float min_dist = std::numeric_limits<float>::max();
+    float min_dist = (std::numeric_limits<float>::max)();
     SliceObject* found = nullptr;
     for (const auto& object : slice_objects_) {
         if (!object->visible()) continue;

--- a/gui/src/graphics/simple_object.cpp
+++ b/gui/src/graphics/simple_object.cpp
@@ -161,7 +161,7 @@ void SimpleObject::init() {
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO_);
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(unsigned int), indices.data(), GL_STATIC_DRAW);
 
-    int vertex_size = vertices.size() / num_indices;
+    int vertex_size = static_cast<int>(vertices.size() / num_indices);
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, vertex_size * sizeof(float), (void*)0);
     glEnableVertexAttribArray(0);
     if (vertex_size == 6) {
@@ -178,12 +178,12 @@ void SimpleObject::render(Renderer* renderer) {
 
     glBindVertexArray(VAO_);
     if (model_.mode == Mode::SURFACE) {
-        glDrawElements(GL_TRIANGLES, model_.indices.size(), GL_UNSIGNED_INT, 0);
+        glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(model_.indices.size()), GL_UNSIGNED_INT, 0);
     } else {
 #ifndef __APPLE__
         glLineWidth(0.5f);
 #endif
-        glDrawElements(GL_LINES, model_.indices.size(), GL_UNSIGNED_INT, 0);
+        glDrawElements(GL_LINES, static_cast<GLsizei>(model_.indices.size()), GL_UNSIGNED_INT, 0);
     }
 }
 

--- a/gui/src/graphics/slice_component.cpp
+++ b/gui/src/graphics/slice_component.cpp
@@ -29,7 +29,7 @@ void SliceComponent::addSliceObject(SliceObject* obj) {
     static std::array<Plane, MAX_NUM_SLICES> planes { Plane::YZ, Plane::XZ, Plane::XY };
 
     Slice slice;
-    slice.id = slices_.size();
+    slice.id = static_cast<uint32_t>(slices_.size());
     slice.timestamp = slice.id;
     slice.object = obj;
     slice.plane = planes[slices_.size()];
@@ -90,8 +90,8 @@ void SliceComponent::drawStatistics(rpc::ServerState_State) {
                 float bin_width = 1.f;
                 if (bin_centers.size() > 1) bin_width = bin_centers[1] - bin_centers[0];
 
-                ImPlot::PlotBars(("##Histogram_" + name).c_str(),
-                                 bin_centers.data(), bin_counts.data(), bin_centers.size(), 0.5f * bin_width);
+                ImPlot::PlotBars(("##Histogram_" + name).c_str(), bin_centers.data(), bin_counts.data(),
+                                 static_cast<int>(bin_centers.size()), 0.5f * bin_width);
             }
             ImPlot::EndPlot();
         }
@@ -103,7 +103,7 @@ RpcClient::State SliceComponent::updateServerParams() const {
     for (auto& slice : slices_) {
         CHECK_CLIENT_STATE(client_->setSlice(slice.timestamp, slice.object->orientation()))
     }
-    return RpcClient::State::OK;
+    return RpcClient::State::SUCCESS;
 }
 
 bool SliceComponent::setData(size_t timestamp, const std::string& data, uint32_t x, uint32_t y) {

--- a/gui/src/graphics/volume_component.cpp
+++ b/gui/src/graphics/volume_component.cpp
@@ -118,8 +118,8 @@ bool VolumeComponent::drawStatistics(rpc::ServerState_State) {
                 float bin_width = 1.f;
                 if (bin_centers.size() > 1) bin_width = bin_centers[1] - bin_centers[0];
 
-                ImPlot::PlotBars("##Histogram_Volume",
-                                 bin_centers.data(), bin_counts.data(), bin_centers.size(), 0.5f * bin_width);
+                ImPlot::PlotBars("##Histogram_Volume", bin_centers.data(), bin_counts.data(),
+                                 static_cast<int>(bin_centers.size()), 0.5f * bin_width);
             }
             ImPlot::EndPlot();
         }
@@ -135,7 +135,7 @@ void VolumeComponent::preRender() {
         auto mat = MaterialManager::instance().getMaterial<TransferFunc>(voxel_object_->materialID());
         const auto& v = data_.minMaxVals();
         if (v) mat->registerMinMaxVals(v.value());
-        
+
         if (update_texture_) {
             if (data_.empty()) {
                 voxel_object_->resetIntensity();
@@ -159,7 +159,7 @@ void VolumeComponent::preRender() {
 
 RpcClient::State VolumeComponent::updateServerParams() const {
     CHECK_CLIENT_STATE(client_->setVolume(display_policy_ != DISABLE))
-    return RpcClient::State::OK;
+    return RpcClient::State::SUCCESS;
 }
 
 bool VolumeComponent::setShard(uint32_t pos, const std::string& data, uint32_t x, uint32_t y, uint32_t z) {

--- a/gui/src/graphics/voxel_object.cpp
+++ b/gui/src/graphics/voxel_object.cpp
@@ -114,7 +114,7 @@ void VoxelObject::Model::renderOnFramebuffer(Framebuffer *fb,
     glActiveTexture(GL_TEXTURE3);
     glBindTexture(GL_TEXTURE_2D, fb->light_texture_);
 
-    for (int i = num_slices_; i >= 0; --i) {
+    for (int i = static_cast<int>(num_slices_); i >= 0; --i) {
         glDrawBuffer(GL_COLOR_ATTACHMENT1);
 
         vslice_shader->use();

--- a/gui/src/graphics/widgets/material_widget.cpp
+++ b/gui/src/graphics/widgets/material_widget.cpp
@@ -121,7 +121,7 @@ void TransferFuncWidget::renderLevelsControl() {
     if (step_size < 0.01f) step_size = 0.01f; // avoid a tiny step size
     ImGui::DragFloatRange2(("Min / Max" + id_).c_str(), &material_->min_val_, &material_->max_val_, step_size,
                            std::numeric_limits<float>::lowest(), // min() does not work
-                           std::numeric_limits<float>::max());
+                           (std::numeric_limits<float>::max)());
     ImGui::EndDisabled();
 }
 
@@ -139,7 +139,7 @@ void TransferFuncWidget::renderAlphaEditor() {
     ImDrawList *draw_list = ImGui::GetWindowDrawList();
     draw_list->AddRect(canvas_pos, {canvas_pos.x + canvas_size.x, canvas_pos.y + canvas_size.y}, frame_color_);
 
-    float radius_p = std::max(4.f / canvas_size.x, 0.008f);
+    float radius_p = (std::max)(4.f / canvas_size.x, 0.008f);
     float radius_s = 2 * radius_p;
     bool alpha_changed = false;
 

--- a/gui/src/rpc_client.cpp
+++ b/gui/src/rpc_client.cpp
@@ -80,7 +80,7 @@ std::optional<rpc::ServerState_State> RpcClient::getServerState() {
 
     grpc::ClientContext context;
     grpc::Status status = control_stub_->GetServerState(&context, request, &reply);
-    if (checkStatus(status) != State::OK) return std::nullopt;
+    if (checkStatus(status) != State::SUCCESS) return std::nullopt;
     return reply.state();
 }
 
@@ -291,7 +291,7 @@ void RpcClient::startReadingProjectionStream() {
 
 RpcClient::State RpcClient::checkStatus(const grpc::Status& status, bool warn_on_unavailable_server) const {
     auto code = status.error_code();
-    if (code == grpc::StatusCode::OK) return State::OK;
+    if (code == grpc::StatusCode::OK) return State::SUCCESS;
 
     const std::string& msg = status.error_message();
     if (code == grpc::StatusCode::UNAVAILABLE) {
@@ -308,7 +308,7 @@ RpcClient::State RpcClient::checkStatus(const grpc::Status& status, bool warn_on
         log::error("Unexpected RPC error {}: {}", code, msg);
         std::exit(EXIT_FAILURE);
     }
-    return State::ERROR;
+    return State::FAILURE;
 }
 
 } // namespace recastx::gui

--- a/recon/CMakeLists.txt
+++ b/recon/CMakeLists.txt
@@ -107,9 +107,7 @@ if (BENCHMARK)
     target_compile_definitions(${RECON_LIB} PRIVATE BENCHMARK)
 endif()
 
-target_compile_options(${RECON_LIB}
-        PUBLIC -Wall -Wextra -Wfatal-errors -fPIC -static)
-
+target_compile_options(${RECON_LIB} PUBLIC -Wall -Wextra -Wfatal-errors -fPIC -static)
 target_compile_definitions(${RECON_LIB} PUBLIC VERBOSITY=${VERBOSITY})
 
 if (BUILD_TEST)


### PR DESCRIPTION
Fixed Windows-related build, path and CPP-Standard implementation issues and added Windows-specific build instructions in recastx-gui.

Building and execution are both now possible on windows, although some rendering issues still remain.